### PR TITLE
WordPress 4.4 の get_the_post_thumbnail() 仕様変更に対応

### DIFF
--- a/head-cleaner.php
+++ b/head-cleaner.php
@@ -3217,7 +3217,11 @@ jQuery(function($){
 			// get the thumbnail
 			$thumb = '';
 			if ( function_exists('has_post_thumbnail') && has_post_thumbnail($id) ) {
-				$thumb = preg_replace("/^.*['\"](https?:\/\/[^'\"]*)['\"].*/i","$1",get_the_post_thumbnail($id));
+				if ($this->wp44) {
+					$thumb = get_the_post_thumbnail_url($id);
+				} else {
+					$thumb = preg_replace("/^.*['\"](https?:\/\/[^'\"]*)['\"].*/i", "$1", get_the_post_thumbnail($id));
+				}
 			} else {
 				$attachments = get_children(array(
 					'post_parent' => $id ,

--- a/includes/common-controller.php
+++ b/includes/common-controller.php
@@ -27,7 +27,7 @@ class wokController {
 	var $admin_option, $admin_action, $admin_hook;
 	var $note, $error;
 	var $charset;
-	var $wp25, $wp26, $wp27, $wp28, $wp29, $wp30, $wp31, $wp32, $wp33, $wp34;
+	var $wp25, $wp26, $wp27, $wp28, $wp29, $wp30, $wp31, $wp32, $wp33, $wp34, $wp44;
 	var $inline_js;
 
 	var $jquery_js  = 'includes/js/jquery-1.4.2.min.js';
@@ -52,6 +52,7 @@ class wokController {
 		$this->wp32    = version_compare($wp_version, "3.2", ">=");
 		$this->wp33    = version_compare($wp_version, "3.3", ">=");
 		$this->wp34    = version_compare($wp_version, "3.4", ">=");
+		$this->wp44    = version_compare($wp_version, "4.4", ">=");
 
 		$this->setPluginDir($file);
 		$this->loadTextdomain();


### PR DESCRIPTION
`get_the_post_thumbnail()` はWordPress 4.4 から `srcset` を出力するようになっていて、これまでの正規表現による URL 抽出がうまくいかないようです。

代わりに 4.4 から `get_the_post_thumbnail_url()` が実装されてサムネイルの URL が直接取れるようになったので、コアが 4.4 以上ならこちらの関数を使うようにしました。
