### PR TITLE
og:image 用の画像を添付ファイルからフルサイズで取得

### DIFF
--- a/head-cleaner.php
+++ b/head-cleaner.php
@@ -3230,7 +3230,7 @@ jQuery(function($){
 					'orderby' => 'menu_order' ,
 					));
 				foreach ($attachments as $attachment) {
-					$image_src = wp_get_attachment_image_src($attachment->ID);
+					$image_src = wp_get_attachment_image_src($attachment->ID, 'full');
 					$thumb = (isset($image_src[0]) ? $image_src[0] : '');
 					unset($image_src);
 					break;


### PR DESCRIPTION
アイキャッチ画像がない場合に投稿の添付ファイルから画像を取得するとき、`wp_get_attachment_image_src()` のデフォルトだと `thumbnail` サイズが返ってきますけど、今はより大きな画像が求められるので `full` で取った方がいいのではないでしょうか。
